### PR TITLE
Fix build issue with hq2x.sv

### DIFF
--- a/analogizer/hq2x.sv
+++ b/analogizer/hq2x.sv
@@ -264,6 +264,8 @@ always_ff@(posedge clock) begin
 	q <= ram[rdaddress];
 end
 
+endmodule
+	
 module hq2x_buf2 #(parameter NUMWORDS, parameter AWIDTH, parameter DWIDTH)
 (
 	input                 clock,


### PR DESCRIPTION
While trying to compile design from Quartus Prime Lite, it report a missing "endmodule" at the end of file.
Searching a little lead me to a missing endmodule in hq2x_buf, just before the hq2x_buf2 module definition.

I am a total noob on FPGA Dev, last time i done something in VHDL was at school in 2005... Fell fee to dump it if stupid.